### PR TITLE
AST parsers

### DIFF
--- a/ASTParsers/esprima.js
+++ b/ASTParsers/esprima.js
@@ -1,0 +1,49 @@
+'use strict'
+
+let esprima = require('esprima'),
+    util = require('util');
+
+let query = require('./query'),
+    syntax = esprima.parse(query),
+    arrowFunction = syntax.body[0].expression;
+let personVarName = arrowFunction.params[0].name,
+    queryBody = arrowFunction.body;
+var newQueryBody, keyVals;
+[newQueryBody, keyVals] = removeExplicitKeys(queryBody);
+arrowFunction.body = newQueryBody;
+console.log(newQueryBody);
+console.log(keyVals);
+
+function getExplicitKeyVal(expr, personVarName) {
+  if (expr.type === 'BinaryExpression' && expr.operator === '===') {
+    let lExpr = expr.left;
+    if (lExpr.type === "MemberExpression") {
+      let rExpr = expr.right;
+      if (rExpr.type === 'Literal') {
+        return [ lExpr.property.name, rExpr.value];
+      }
+    }
+  }
+  return null;
+}
+
+function removeExplicitKeys(logExpr) {
+  if (logExpr.type !== 'LogicalExpression' || logExpr.operator !== '&&') {
+    let keyVal = getExplicitKeyVal(logExpr);
+    return keyVal !== null
+         ? [null, [keyVal]]
+         : [Object.assign(logExpr), []];
+  } else {
+    let [lRes, lKeyVals] = removeExplicitKeys(logExpr.left),
+        [rRes, rKeyVals] = removeExplicitKeys(logExpr.right),
+        allKeyVals = lKeyVals.concat(rKeyVals),
+        allRes = lRes === null
+               ? ( rRes === null
+                 ? null
+                 : rRes)
+               : ( rRes === null
+                 ? lRes 
+                 : Object.assign({}, logExpr));
+    return [allRes, allKeyVals];
+  }
+}

--- a/ASTParsers/esprima.js
+++ b/ASTParsers/esprima.js
@@ -1,49 +1,8 @@
 'use strict'
 
-let esprima = require('esprima'),
-    util = require('util');
+let esprima = require('esprima');
 
-let query = require('./query'),
-    syntax = esprima.parse(query),
-    arrowFunction = syntax.body[0].expression;
-let personVarName = arrowFunction.params[0].name,
-    queryBody = arrowFunction.body;
-var newQueryBody, keyVals;
-[newQueryBody, keyVals] = removeExplicitKeys(queryBody);
-arrowFunction.body = newQueryBody;
-console.log(newQueryBody);
-console.log(keyVals);
-
-function getExplicitKeyVal(expr, personVarName) {
-  if (expr.type === 'BinaryExpression' && expr.operator === '===') {
-    let lExpr = expr.left;
-    if (lExpr.type === "MemberExpression") {
-      let rExpr = expr.right;
-      if (rExpr.type === 'Literal') {
-        return [ lExpr.property.name, rExpr.value];
-      }
-    }
-  }
-  return null;
-}
-
-function removeExplicitKeys(logExpr) {
-  if (logExpr.type !== 'LogicalExpression' || logExpr.operator !== '&&') {
-    let keyVal = getExplicitKeyVal(logExpr);
-    return keyVal !== null
-         ? [null, [keyVal]]
-         : [Object.assign(logExpr), []];
-  } else {
-    let [lRes, lKeyVals] = removeExplicitKeys(logExpr.left),
-        [rRes, rKeyVals] = removeExplicitKeys(logExpr.right),
-        allKeyVals = lKeyVals.concat(rKeyVals),
-        allRes = lRes === null
-               ? ( rRes === null
-                 ? null
-                 : rRes)
-               : ( rRes === null
-                 ? lRes 
-                 : Object.assign({}, logExpr));
-    return [allRes, allKeyVals];
-  }
+module.exports = {
+  parse: esprima.parse,
+  getProgram: expr => expr
 }

--- a/ASTParsers/package.json
+++ b/ASTParsers/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "esprima": "*",
+    "recast": "*"
+  }
+}

--- a/ASTParsers/query.js
+++ b/ASTParsers/query.js
@@ -1,0 +1,7 @@
+var query = `(person) => (
+  person.name !== '' &&
+  person.age > 18 &&
+  person.city === 'Rome'
+)`;
+
+module.exports = query;

--- a/ASTParsers/recast.js
+++ b/ASTParsers/recast.js
@@ -1,50 +1,11 @@
 'use strict'
 
-let recast = require('recast'),
-    util = require('util');
+let recast = require('recast');
 
-let query = require('./query'),
-    ast = recast.parse(query),
-    arrowFunction = ast.program.body[0].expression;
-let personVarName = arrowFunction.params[0].name,
-    queryBody = arrowFunction.body;
-var newQueryBody, keyVals;
-[newQueryBody, keyVals] = removeExplicitKeys(queryBody);
-arrowFunction.body = newQueryBody;
-//console.log(newQueryBody);
-console.log(keyVals);
-console.log(recast.print(ast).code);
-
-function getExplicitKeyVal(expr, personVarName) {
-  if (expr.type === 'BinaryExpression' && expr.operator === '===') {
-    let lExpr = expr.left;
-    if (lExpr.type === "MemberExpression") {
-      let rExpr = expr.right;
-      if (rExpr.type === 'Literal') {
-        return [ lExpr.property.name, rExpr.value];
-      }
-    }
+module.exports = {
+  parse: recast.parse,
+  getProgram: expr => expr.program,
+  print: function (x) {
+    return recast.print(x).code;
   }
-  return null;
-}
-
-function removeExplicitKeys(logExpr) {
-  if (logExpr.type !== 'LogicalExpression' || logExpr.operator !== '&&') {
-    let keyVal = getExplicitKeyVal(logExpr);
-    return keyVal !== null
-         ? [null, [keyVal]]
-         : [Object.assign(logExpr), []];
-  } else {
-    let [lRes, lKeyVals] = removeExplicitKeys(logExpr.left),
-        [rRes, rKeyVals] = removeExplicitKeys(logExpr.right),
-        allKeyVals = lKeyVals.concat(rKeyVals),
-        allRes = lRes === null
-               ? ( rRes === null
-                 ? null
-                 : rRes)
-               : ( rRes === null
-                 ? lRes 
-                 : Object.assign({}, logExpr));
-    return [allRes, allKeyVals];
-  }
-}
+};

--- a/ASTParsers/recast.js
+++ b/ASTParsers/recast.js
@@ -1,0 +1,50 @@
+'use strict'
+
+let recast = require('recast'),
+    util = require('util');
+
+let query = require('./query'),
+    ast = recast.parse(query),
+    arrowFunction = ast.program.body[0].expression;
+let personVarName = arrowFunction.params[0].name,
+    queryBody = arrowFunction.body;
+var newQueryBody, keyVals;
+[newQueryBody, keyVals] = removeExplicitKeys(queryBody);
+arrowFunction.body = newQueryBody;
+//console.log(newQueryBody);
+console.log(keyVals);
+console.log(recast.print(ast).code);
+
+function getExplicitKeyVal(expr, personVarName) {
+  if (expr.type === 'BinaryExpression' && expr.operator === '===') {
+    let lExpr = expr.left;
+    if (lExpr.type === "MemberExpression") {
+      let rExpr = expr.right;
+      if (rExpr.type === 'Literal') {
+        return [ lExpr.property.name, rExpr.value];
+      }
+    }
+  }
+  return null;
+}
+
+function removeExplicitKeys(logExpr) {
+  if (logExpr.type !== 'LogicalExpression' || logExpr.operator !== '&&') {
+    let keyVal = getExplicitKeyVal(logExpr);
+    return keyVal !== null
+         ? [null, [keyVal]]
+         : [Object.assign(logExpr), []];
+  } else {
+    let [lRes, lKeyVals] = removeExplicitKeys(logExpr.left),
+        [rRes, rKeyVals] = removeExplicitKeys(logExpr.right),
+        allKeyVals = lKeyVals.concat(rKeyVals),
+        allRes = lRes === null
+               ? ( rRes === null
+                 ? null
+                 : rRes)
+               : ( rRes === null
+                 ? lRes 
+                 : Object.assign({}, logExpr));
+    return [allRes, allKeyVals];
+  }
+}

--- a/ASTParsers/transformFuncs.js
+++ b/ASTParsers/transformFuncs.js
@@ -1,0 +1,38 @@
+function getExplicitKeyVal(expr, personVarName) {
+  if (expr.type === 'BinaryExpression' && expr.operator === '===') {
+    let lExpr = expr.left;
+    if (lExpr.type === "MemberExpression") {
+      let rExpr = expr.right;
+      if (rExpr.type === 'Literal') {
+        return [ lExpr.property.name, rExpr.value];
+      }
+    }
+  }
+  return null;
+}
+
+function removeExplicitKeys(logExpr) {
+  if (logExpr.type !== 'LogicalExpression' || logExpr.operator !== '&&') {
+    let keyVal = getExplicitKeyVal(logExpr);
+    return keyVal !== null
+         ? [null, [keyVal]]
+         : [Object.assign(logExpr), []];
+  } else {
+    let [lRes, lKeyVals] = removeExplicitKeys(logExpr.left),
+        [rRes, rKeyVals] = removeExplicitKeys(logExpr.right),
+        allKeyVals = lKeyVals.concat(rKeyVals),
+        allRes = lRes === null
+               ? ( rRes === null
+                 ? null
+                 : rRes)
+               : ( rRes === null
+                 ? lRes 
+                 : Object.assign({}, logExpr));
+    return [allRes, allKeyVals];
+  }
+}
+
+module.exports = {
+  getExplicitKeyVal: getExplicitKeyVal,
+  removeExplicitKeys: removeExplicitKeys
+}

--- a/ASTParsers/transformQuery.js
+++ b/ASTParsers/transformQuery.js
@@ -1,0 +1,23 @@
+'use strict'
+
+let parserName = process.argv[2] || 'recast',
+    astParser = require('./'+parserName),
+    util = require('util');
+
+let query = require('./query'),
+    tf = require('./transformFuncs'),
+    ast = astParser.parse(query),
+    astProgram = astParser.getProgram(ast),
+    arrowFunction = astProgram.body[0].expression;
+
+let personVarName = arrowFunction.params[0].name,
+    queryBody = arrowFunction.body;
+
+var newQueryBody, keyVals;
+[newQueryBody, keyVals] = tf.removeExplicitKeys(queryBody);
+
+arrowFunction.body = newQueryBody;
+
+console.log(keyVals);
+if (typeof astParser.print === 'function')
+  console.log(astParser.print(ast));


### PR DESCRIPTION
Added examples of parsing with esprima and recast.
Target is remove all && clauses that contains check for equality some field of argument object for the any literal. Also it is need to return key - value pairs that algorithm found.
Esprima can parse to AST but can not create source back from changed tree.
Recast can do that because it saves information about locations(row and column of start and end) in the ast that it produces.
